### PR TITLE
fix: support Teams mentions and markdown-friendly messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Paste it, start Claude Code, and ask Claude to log in. It opens your browser for
 
 ## Teams message formatting and @mentions
 
-The Teams message tools (`graph_send_chat_message`, `graph_send_channel_message`, and `graph_reply_to_channel_message`) now default to **HTML mode** and will convert common markdown-like LLM output into Teams-friendly HTML automatically.
+The Teams message tools (`graph_send_chat_message`, `graph_send_channel_message`, and `graph_reply_to_channel_message`) now default to **HTML mode** and convert markdown to Teams-friendly HTML automatically using Python-Markdown.
 
 Examples:
 

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ claude mcp add graph -e AZURE_CLIENT_ID=your-id -e AZURE_TENANT_ID=your-tenant -
 
 Paste it, start Claude Code, and ask Claude to log in. It opens your browser for OAuth sign-in — that's it.
 
-## Teams message formatting and @mentions
+## Message and email formatting
 
-The Teams message tools (`graph_send_chat_message`, `graph_send_channel_message`, and `graph_reply_to_channel_message`) now default to **HTML mode** and convert markdown to Teams-friendly HTML automatically using Python-Markdown.
+The Teams message tools (`graph_send_chat_message`, `graph_send_channel_message`, and `graph_reply_to_channel_message`) and outbound mail tools (`graph_send_mail`, `graph_reply_mail`) now default to **HTML mode** and convert markdown to HTML automatically using Python-Markdown.
 
 Examples:
 
@@ -77,6 +77,8 @@ Examples:
 - `` `code` `` → `<code>...</code>`
 
 If you already have raw HTML, pass it directly and it will be sent as-is.
+
+For email, this means normal LLM-written markdown like `**bold**`, bullet lists, or inline code renders properly instead of showing raw markdown characters.
 
 These tools also support optional top-level Graph API `mentions`, either in raw Graph format or a simplified shape such as:
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,31 @@ claude mcp add graph -e AZURE_CLIENT_ID=your-id -e AZURE_TENANT_ID=your-tenant -
 
 Paste it, start Claude Code, and ask Claude to log in. It opens your browser for OAuth sign-in — that's it.
 
+## Teams message formatting and @mentions
+
+The Teams message tools (`graph_send_chat_message`, `graph_send_channel_message`, and `graph_reply_to_channel_message`) now default to **HTML mode** and will convert common markdown-like LLM output into Teams-friendly HTML automatically.
+
+Examples:
+
+- `**bold**` → `<strong>bold</strong>`
+- `- item` lists → `<ul><li>...</li></ul>`
+- `` `code` `` → `<code>...</code>`
+
+If you already have raw HTML, pass it directly and it will be sent as-is.
+
+These tools also support optional top-level Graph API `mentions`, either in raw Graph format or a simplified shape such as:
+
+```json
+[
+  {
+    "name": "Jane Smith",
+    "user_id": "ef1c916a-3135-4417-ba27-8eb7bd084193"
+  }
+]
+```
+
+Use the corresponding `<at id="0">Jane Smith</at>` tag in the HTML body to trigger a real Teams mention.
+
 ## How it works
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "pydantic>=2.0",
     "pydantic-settings>=2.0",
     "cryptography>=42.0",
+    "Markdown>=3.7",
 ]
 
 [project.scripts]

--- a/src/graph_mcp/tools/chat_tools.py
+++ b/src/graph_mcp/tools/chat_tools.py
@@ -1,6 +1,11 @@
+from __future__ import annotations
+
+from typing import Any
+
 from graph_mcp._select_fields import CHAT_FIELDS
 from graph_mcp.graph_client import graph_client
 from graph_mcp.responses import require_auth, success_response
+from graph_mcp.tools.message_tools import build_chat_message_payload
 
 
 def register_chat_tools(mcp):
@@ -37,17 +42,29 @@ def register_chat_tools(mcp):
     @mcp.tool()
     @require_auth
     async def graph_send_chat_message(
-        chat_id: str, message: str, is_html: bool = False
+        chat_id: str,
+        message: str,
+        is_html: bool = True,
+        mentions: list[dict[str, Any]] | None = None,
     ) -> str:
         """Send a message to a chat.
 
         Args:
             chat_id: The chat ID to send the message to.
-            message: The message text to send.
-            is_html: Whether the message is HTML (default: plain text).
+            message: The message text to send. By default, markdown-like text is
+                converted to Teams-compatible HTML automatically.
+            is_html: Whether to send HTML content (default: True). If True and
+                the message is not already HTML, markdown-like text is converted
+                to HTML before sending.
+            mentions: Optional mentions to include. Accepts either raw Microsoft
+                Graph `mentions` objects or simplified items like
+                `{"name": "Jane Smith", "user_id": "..."}`.
         """
-        content_type = "html" if is_html else "text"
-        body = {"body": {"contentType": content_type, "content": message}}
+        body = build_chat_message_payload(
+            message=message,
+            is_html=is_html,
+            mentions=mentions,
+        )
         result = await graph_client.post(
             f"/chats/{chat_id}/messages", json_body=body
         )

--- a/src/graph_mcp/tools/mail_tools.py
+++ b/src/graph_mcp/tools/mail_tools.py
@@ -1,6 +1,7 @@
 from graph_mcp._select_fields import MAIL_LIST_FIELDS
 from graph_mcp.graph_client import graph_client
 from graph_mcp.responses import require_auth, success_response
+from graph_mcp.tools.message_tools import build_rich_text_body
 
 
 def register_mail_tools(mcp):
@@ -65,26 +66,31 @@ def register_mail_tools(mcp):
         subject: str,
         body: str,
         cc: list[str] | None = None,
-        is_html: bool = False,
+        is_html: bool = True,
     ) -> str:
         """Send an email.
 
         Args:
             to: List of recipient email addresses.
             subject: Email subject.
-            body: Email body text.
+            body: Email body text. By default, markdown-like text is converted
+                to HTML automatically for better rendering in mail clients.
             cc: Optional list of CC email addresses.
-            is_html: Whether the body is HTML (default: plain text).
+            is_html: Whether to send HTML content (default: True). If True and
+                the body is not already HTML, markdown is converted to HTML
+                before sending.
         """
         to_recipients = [
             {"emailAddress": {"address": addr}} for addr in to
         ]
         message: dict = {
             "subject": subject,
-            "body": {
-                "contentType": "HTML" if is_html else "Text",
-                "content": body,
-            },
+            "body": build_rich_text_body(
+                body,
+                is_html,
+                html_content_type="HTML",
+                text_content_type="Text",
+            ),
             "toRecipients": to_recipients,
         }
         if cc:
@@ -98,20 +104,39 @@ def register_mail_tools(mcp):
     @mcp.tool()
     @require_auth
     async def graph_reply_mail(
-        message_id: str, body: str, reply_all: bool = False
+        message_id: str,
+        body: str,
+        reply_all: bool = False,
+        is_html: bool = True,
     ) -> str:
         """Reply to an email.
 
         Args:
             message_id: The email message ID to reply to.
-            body: The reply body text.
+            body: The reply body text. By default, markdown-like text is
+                converted to HTML automatically for better rendering.
             reply_all: Whether to reply to all recipients (default: reply to sender only).
+            is_html: Whether to send HTML content (default: True). If True and
+                the body is not already HTML, markdown is converted to HTML
+                before sending.
         """
-        action = "replyAll" if reply_all else "reply"
-        payload = {"comment": body}
-        await graph_client.post(
-            f"/me/messages/{message_id}/{action}", json_body=payload
+        create_action = "createReplyAll" if reply_all else "createReply"
+        draft = await graph_client.post(
+            f"/me/messages/{message_id}/{create_action}"
         )
+        draft_id = draft["id"]
+        await graph_client.patch(
+            f"/me/messages/{draft_id}",
+            json_body={
+                "body": build_rich_text_body(
+                    body,
+                    is_html,
+                    html_content_type="HTML",
+                    text_content_type="Text",
+                )
+            },
+        )
+        await graph_client.post(f"/me/messages/{draft_id}/send")
         return success_response(
             {"status": f"{'Reply all' if reply_all else 'Reply'} sent"}
         )

--- a/src/graph_mcp/tools/message_tools.py
+++ b/src/graph_mcp/tools/message_tools.py
@@ -79,20 +79,30 @@ def normalize_mentions(mentions: list[dict[str, Any]] | None) -> list[dict[str, 
     return normalized
 
 
+def build_rich_text_body(
+    message: str,
+    is_html: bool = True,
+    *,
+    html_content_type: str = "html",
+    text_content_type: str = "text",
+) -> dict[str, Any]:
+    if is_html:
+        content = message if _looks_like_html(message) else markdown_to_html(message)
+        content_type = html_content_type
+    else:
+        content = message
+        content_type = text_content_type
+
+    return {"contentType": content_type, "content": content}
+
+
 def build_chat_message_payload(
     message: str,
     is_html: bool = True,
     mentions: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
-    if is_html:
-        content = message if _looks_like_html(message) else markdown_to_html(message)
-        content_type = "html"
-    else:
-        content = message
-        content_type = "text"
-
     payload: dict[str, Any] = {
-        "body": {"contentType": content_type, "content": content}
+        "body": build_rich_text_body(message, is_html)
     }
 
     normalized_mentions = normalize_mentions(mentions)

--- a/src/graph_mcp/tools/message_tools.py
+++ b/src/graph_mcp/tools/message_tools.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import html
+import re
+from typing import Any
+
+_HTML_TAG_RE = re.compile(r"<\s*[a-zA-Z][^>]*>")
+_CODE_BLOCK_RE = re.compile(r"```(?:[\w+-]+)?\n?(.*?)```", re.DOTALL)
+_INLINE_CODE_RE = re.compile(r"`([^`]+)`")
+_BOLD_RE = re.compile(r"\*\*(.+?)\*\*")
+_ITALIC_RE = re.compile(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)")
+
+
+def _looks_like_html(text: str) -> bool:
+    return bool(_HTML_TAG_RE.search(text))
+
+
+def _apply_inline_markdown(text: str) -> str:
+    text = _CODE_BLOCK_RE.sub(lambda m: f"<pre><code>{html.escape(m.group(1).strip())}</code></pre>", text)
+    text = _INLINE_CODE_RE.sub(lambda m: f"<code>{html.escape(m.group(1))}</code>", text)
+    text = _BOLD_RE.sub(r"<strong>\1</strong>", text)
+    text = _ITALIC_RE.sub(r"<em>\1</em>", text)
+    return text
+
+
+def markdown_to_html(message: str) -> str:
+    """Convert common LLM markdown into Teams-friendly HTML."""
+    if not message.strip():
+        return ""
+
+    lines = message.splitlines()
+    chunks: list[str] = []
+    paragraph: list[str] = []
+    list_items: list[str] = []
+
+    def flush_paragraph() -> None:
+        if paragraph:
+            text = " ".join(part.strip() for part in paragraph if part.strip())
+            if text:
+                escaped = html.escape(text)
+                chunks.append(f"<p>{_apply_inline_markdown(escaped)}</p>")
+            paragraph.clear()
+
+    def flush_list() -> None:
+        if list_items:
+            rendered_items = "".join(
+                f"<li>{_apply_inline_markdown(html.escape(item.strip()))}</li>"
+                for item in list_items
+                if item.strip()
+            )
+            if rendered_items:
+                chunks.append(f"<ul>{rendered_items}</ul>")
+            list_items.clear()
+
+    for raw_line in lines:
+        line = raw_line.rstrip()
+        stripped = line.strip()
+
+        if not stripped:
+            flush_paragraph()
+            flush_list()
+            continue
+
+        if stripped.startswith(("- ", "* ")):
+            flush_paragraph()
+            list_items.append(stripped[2:])
+            continue
+
+        flush_list()
+        paragraph.append(stripped)
+
+    flush_paragraph()
+    flush_list()
+
+    rendered = "".join(chunks)
+    return rendered or f"<p>{_apply_inline_markdown(html.escape(message))}</p>"
+
+
+def normalize_mentions(mentions: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+    if not mentions:
+        return []
+
+    normalized: list[dict[str, Any]] = []
+    for index, mention in enumerate(mentions):
+        if "mentioned" in mention and "mentionText" in mention:
+            entry = dict(mention)
+            entry.setdefault("id", index)
+            normalized.append(entry)
+            continue
+
+        raw_id = mention.get("id")
+        mention_id = mention.get("mention_id")
+        if mention_id is None:
+            mention_id = raw_id if isinstance(raw_id, int) else index
+
+        mention_text = (
+            mention.get("name")
+            or mention.get("display_name")
+            or mention.get("displayName")
+            or mention.get("mentionText")
+            or mention.get("text")
+        )
+        user_id = (
+            mention.get("user_id")
+            or mention.get("userId")
+            or (raw_id if isinstance(raw_id, str) else None)
+        )
+        user_identity_type = (
+            mention.get("user_identity_type")
+            or mention.get("userIdentityType")
+            or "aadUser"
+        )
+
+        if mention_text is None or user_id is None:
+            raise ValueError(
+                "Each mention must include either raw Graph mention fields or "
+                "a simplified shape with `name`/`display_name` and `user_id`."
+            )
+
+        normalized.append(
+            {
+                "id": mention_id,
+                "mentionText": mention_text,
+                "mentioned": {
+                    "user": {
+                        "id": user_id,
+                        "displayName": mention_text,
+                        "userIdentityType": user_identity_type,
+                    }
+                },
+            }
+        )
+
+    return normalized
+
+
+def build_chat_message_payload(
+    message: str,
+    is_html: bool = True,
+    mentions: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    if is_html:
+        content = message if _looks_like_html(message) else markdown_to_html(message)
+        content_type = "html"
+    else:
+        content = message
+        content_type = "text"
+
+    payload: dict[str, Any] = {
+        "body": {"contentType": content_type, "content": content}
+    }
+
+    normalized_mentions = normalize_mentions(mentions)
+    if normalized_mentions:
+        payload["mentions"] = normalized_mentions
+
+    return payload

--- a/src/graph_mcp/tools/message_tools.py
+++ b/src/graph_mcp/tools/message_tools.py
@@ -1,79 +1,24 @@
 from __future__ import annotations
 
-import html
 import re
 from typing import Any
 
+from markdown import markdown
+
 _HTML_TAG_RE = re.compile(r"<\s*[a-zA-Z][^>]*>")
-_CODE_BLOCK_RE = re.compile(r"```(?:[\w+-]+)?\n?(.*?)```", re.DOTALL)
-_INLINE_CODE_RE = re.compile(r"`([^`]+)`")
-_BOLD_RE = re.compile(r"\*\*(.+?)\*\*")
-_ITALIC_RE = re.compile(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)")
+_MARKDOWN_EXTENSIONS = ["extra", "sane_lists", "nl2br"]
 
 
 def _looks_like_html(text: str) -> bool:
     return bool(_HTML_TAG_RE.search(text))
 
 
-def _apply_inline_markdown(text: str) -> str:
-    text = _CODE_BLOCK_RE.sub(lambda m: f"<pre><code>{html.escape(m.group(1).strip())}</code></pre>", text)
-    text = _INLINE_CODE_RE.sub(lambda m: f"<code>{html.escape(m.group(1))}</code>", text)
-    text = _BOLD_RE.sub(r"<strong>\1</strong>", text)
-    text = _ITALIC_RE.sub(r"<em>\1</em>", text)
-    return text
-
-
 def markdown_to_html(message: str) -> str:
-    """Convert common LLM markdown into Teams-friendly HTML."""
+    """Convert markdown into Teams-friendly HTML via Python-Markdown."""
     if not message.strip():
         return ""
 
-    lines = message.splitlines()
-    chunks: list[str] = []
-    paragraph: list[str] = []
-    list_items: list[str] = []
-
-    def flush_paragraph() -> None:
-        if paragraph:
-            text = " ".join(part.strip() for part in paragraph if part.strip())
-            if text:
-                escaped = html.escape(text)
-                chunks.append(f"<p>{_apply_inline_markdown(escaped)}</p>")
-            paragraph.clear()
-
-    def flush_list() -> None:
-        if list_items:
-            rendered_items = "".join(
-                f"<li>{_apply_inline_markdown(html.escape(item.strip()))}</li>"
-                for item in list_items
-                if item.strip()
-            )
-            if rendered_items:
-                chunks.append(f"<ul>{rendered_items}</ul>")
-            list_items.clear()
-
-    for raw_line in lines:
-        line = raw_line.rstrip()
-        stripped = line.strip()
-
-        if not stripped:
-            flush_paragraph()
-            flush_list()
-            continue
-
-        if stripped.startswith(("- ", "* ")):
-            flush_paragraph()
-            list_items.append(stripped[2:])
-            continue
-
-        flush_list()
-        paragraph.append(stripped)
-
-    flush_paragraph()
-    flush_list()
-
-    rendered = "".join(chunks)
-    return rendered or f"<p>{_apply_inline_markdown(html.escape(message))}</p>"
+    return markdown(message, extensions=_MARKDOWN_EXTENSIONS)
 
 
 def normalize_mentions(mentions: list[dict[str, Any]] | None) -> list[dict[str, Any]]:

--- a/src/graph_mcp/tools/teams_tools.py
+++ b/src/graph_mcp/tools/teams_tools.py
@@ -1,6 +1,11 @@
+from __future__ import annotations
+
+from typing import Any
+
 from graph_mcp._select_fields import CHANNEL_FIELDS, TEAM_FIELDS
 from graph_mcp.graph_client import graph_client
 from graph_mcp.responses import require_auth, success_response
+from graph_mcp.tools.message_tools import build_chat_message_payload
 
 
 def register_teams_tools(mcp):
@@ -50,18 +55,28 @@ def register_teams_tools(mcp):
         team_id: str,
         channel_id: str,
         message: str,
-        is_html: bool = False,
+        is_html: bool = True,
+        mentions: list[dict[str, Any]] | None = None,
     ) -> str:
         """Send a message to a channel.
 
         Args:
             team_id: The team ID.
             channel_id: The channel ID.
-            message: The message text to send.
-            is_html: Whether the message is HTML (default: plain text).
+            message: The message text to send. By default, markdown-like text is
+                converted to Teams-compatible HTML automatically.
+            is_html: Whether to send HTML content (default: True). If True and
+                the message is not already HTML, markdown-like text is converted
+                to HTML before sending.
+            mentions: Optional mentions to include. Accepts either raw Microsoft
+                Graph `mentions` objects or simplified items like
+                `{"name": "Jane Smith", "user_id": "..."}`.
         """
-        content_type = "html" if is_html else "text"
-        body = {"body": {"contentType": content_type, "content": message}}
+        body = build_chat_message_payload(
+            message=message,
+            is_html=is_html,
+            mentions=mentions,
+        )
         result = await graph_client.post(
             f"/teams/{team_id}/channels/{channel_id}/messages", json_body=body
         )
@@ -110,7 +125,8 @@ def register_teams_tools(mcp):
         channel_id: str,
         message_id: str,
         message: str,
-        is_html: bool = False,
+        is_html: bool = True,
+        mentions: list[dict[str, Any]] | None = None,
     ) -> str:
         """Reply to a channel message.
 
@@ -118,11 +134,20 @@ def register_teams_tools(mcp):
             team_id: The team ID.
             channel_id: The channel ID.
             message_id: The message ID to reply to.
-            message: The reply text.
-            is_html: Whether the message is HTML (default: plain text).
+            message: The reply text. By default, markdown-like text is converted
+                to Teams-compatible HTML automatically.
+            is_html: Whether to send HTML content (default: True). If True and
+                the message is not already HTML, markdown-like text is converted
+                to HTML before sending.
+            mentions: Optional mentions to include. Accepts either raw Microsoft
+                Graph `mentions` objects or simplified items like
+                `{"name": "Jane Smith", "user_id": "..."}`.
         """
-        content_type = "html" if is_html else "text"
-        body = {"body": {"contentType": content_type, "content": message}}
+        body = build_chat_message_payload(
+            message=message,
+            is_html=is_html,
+            mentions=mentions,
+        )
         result = await graph_client.post(
             f"/teams/{team_id}/channels/{channel_id}/messages/{message_id}/replies",
             json_body=body,


### PR DESCRIPTION
## Summary
- add shared Teams message payload helpers
- support top-level Graph `mentions` payloads in chat/channel send + reply tools
- default Teams messaging tools to HTML mode and convert common markdown-like LLM output to Teams-friendly HTML
- document the new formatting and mention behavior in the README

## Testing
- python3 -m compileall src
- direct smoke test of `build_chat_message_payload()` for markdown conversion and mention payload generation

Fixes #1
Fixes #2