### PR TITLE
Make Graph message formatting explicit HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,17 +68,25 @@ Paste it, start Claude Code, and ask Claude to log in. It opens your browser for
 
 ## Message and email formatting
 
-The Teams message tools (`graph_send_chat_message`, `graph_send_channel_message`, and `graph_reply_to_channel_message`) and outbound mail tools (`graph_send_mail`, `graph_reply_mail`) now default to **HTML mode** and convert markdown to HTML automatically using Python-Markdown.
+The Teams message tools (`graph_send_chat_message`, `graph_send_channel_message`,
+and `graph_reply_to_channel_message`) and outbound mail tools (`graph_send_mail`,
+`graph_reply_mail`) default to **HTML mode**. When `is_html=true`, pass explicit
+HTML and it will be sent as-is. Markdown is not converted automatically.
 
-Examples:
+Use Teams/Graph-compatible HTML for formatted messages:
 
-- `**bold**` → `<strong>bold</strong>`
-- `- item` lists → `<ul><li>...</li></ul>`
-- `` `code` `` → `<code>...</code>`
+```html
+<p><strong>Status update</strong></p>
+<ul>
+  <li>Use <code>&lt;strong&gt;</code> for bold text.</li>
+  <li>Use <code>&lt;pre&gt;&lt;code&gt;</code> for multi-line code blocks.</li>
+  <li>Use placeholder text like <code>YOUR_NAME</code>, not <code>&lt;your-name&gt;</code>.</li>
+</ul>
+```
 
-If you already have raw HTML, pass it directly and it will be sent as-is.
+Use `is_html=false` for plain text bodies. Plain text is sent as exact text and is not formatted.
 
-For email, this means normal LLM-written markdown like `**bold**`, bullet lists, or inline code renders properly instead of showing raw markdown characters.
+For email, the same rule applies: use explicit HTML when `is_html=true`, or plain text when `is_html=false`.
 
 These tools also support optional top-level Graph API `mentions`, either in raw Graph format or a simplified shape such as:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ dependencies = [
     "pydantic>=2.0",
     "pydantic-settings>=2.0",
     "cryptography>=42.0",
-    "Markdown>=3.7",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graph-mcp"
-version = "0.5.0"
+version = "0.5.1"
 description = "MCP server for Microsoft Teams, Outlook Calendar, and Mail via Microsoft Graph API"
 readme = "README.md"
 authors = [

--- a/src/graph_mcp/tools/chat_tools.py
+++ b/src/graph_mcp/tools/chat_tools.py
@@ -51,11 +51,10 @@ def register_chat_tools(mcp):
 
         Args:
             chat_id: The chat ID to send the message to.
-            message: The message text to send. By default, markdown-like text is
-                converted to Teams-compatible HTML automatically.
-            is_html: Whether to send HTML content (default: True). If True and
-                the message is not already HTML, markdown-like text is converted
-                to HTML before sending.
+            message: The message content to send. When `is_html` is true, send
+                explicit Teams-compatible HTML; markdown is not converted.
+            is_html: Whether to send the message as HTML content (default:
+                True). Use false for plain text.
             mentions: Optional mentions to include. Accepts either raw Microsoft
                 Graph `mentions` objects or simplified items like
                 `{"name": "Jane Smith", "user_id": "..."}`.

--- a/src/graph_mcp/tools/mail_tools.py
+++ b/src/graph_mcp/tools/mail_tools.py
@@ -73,12 +73,11 @@ def register_mail_tools(mcp):
         Args:
             to: List of recipient email addresses.
             subject: Email subject.
-            body: Email body text. By default, markdown-like text is converted
-                to HTML automatically for better rendering in mail clients.
+            body: Email body content. When `is_html` is true, send explicit
+                HTML; markdown is not converted.
             cc: Optional list of CC email addresses.
-            is_html: Whether to send HTML content (default: True). If True and
-                the body is not already HTML, markdown is converted to HTML
-                before sending.
+            is_html: Whether to send the email body as HTML content (default:
+                True). Use false for plain text.
         """
         to_recipients = [
             {"emailAddress": {"address": addr}} for addr in to
@@ -113,12 +112,11 @@ def register_mail_tools(mcp):
 
         Args:
             message_id: The email message ID to reply to.
-            body: The reply body text. By default, markdown-like text is
-                converted to HTML automatically for better rendering.
+            body: The reply body content. When `is_html` is true, send explicit
+                HTML; markdown is not converted.
             reply_all: Whether to reply to all recipients (default: reply to sender only).
-            is_html: Whether to send HTML content (default: True). If True and
-                the body is not already HTML, markdown is converted to HTML
-                before sending.
+            is_html: Whether to send the reply body as HTML content (default:
+                True). Use false for plain text.
         """
         create_action = "createReplyAll" if reply_all else "createReply"
         draft = await graph_client.post(

--- a/src/graph_mcp/tools/message_tools.py
+++ b/src/graph_mcp/tools/message_tools.py
@@ -1,24 +1,6 @@
 from __future__ import annotations
 
-import re
 from typing import Any
-
-from markdown import markdown
-
-_HTML_TAG_RE = re.compile(r"<\s*[a-zA-Z][^>]*>")
-_MARKDOWN_EXTENSIONS = ["extra", "sane_lists", "nl2br"]
-
-
-def _looks_like_html(text: str) -> bool:
-    return bool(_HTML_TAG_RE.search(text))
-
-
-def markdown_to_html(message: str) -> str:
-    """Convert markdown into Teams-friendly HTML via Python-Markdown."""
-    if not message.strip():
-        return ""
-
-    return markdown(message, extensions=_MARKDOWN_EXTENSIONS)
 
 
 def normalize_mentions(mentions: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
@@ -86,8 +68,9 @@ def build_rich_text_body(
     html_content_type: str = "html",
     text_content_type: str = "text",
 ) -> dict[str, Any]:
+    """Build a Graph message body without changing caller-provided content."""
     if is_html:
-        content = message if _looks_like_html(message) else markdown_to_html(message)
+        content = message
         content_type = html_content_type
     else:
         content = message

--- a/src/graph_mcp/tools/teams_tools.py
+++ b/src/graph_mcp/tools/teams_tools.py
@@ -63,11 +63,10 @@ def register_teams_tools(mcp):
         Args:
             team_id: The team ID.
             channel_id: The channel ID.
-            message: The message text to send. By default, markdown-like text is
-                converted to Teams-compatible HTML automatically.
-            is_html: Whether to send HTML content (default: True). If True and
-                the message is not already HTML, markdown-like text is converted
-                to HTML before sending.
+            message: The message content to send. When `is_html` is true, send
+                explicit Teams-compatible HTML; markdown is not converted.
+            is_html: Whether to send the message as HTML content (default:
+                True). Use false for plain text.
             mentions: Optional mentions to include. Accepts either raw Microsoft
                 Graph `mentions` objects or simplified items like
                 `{"name": "Jane Smith", "user_id": "..."}`.
@@ -134,11 +133,10 @@ def register_teams_tools(mcp):
             team_id: The team ID.
             channel_id: The channel ID.
             message_id: The message ID to reply to.
-            message: The reply text. By default, markdown-like text is converted
-                to Teams-compatible HTML automatically.
-            is_html: Whether to send HTML content (default: True). If True and
-                the message is not already HTML, markdown-like text is converted
-                to HTML before sending.
+            message: The reply content to send. When `is_html` is true, send
+                explicit Teams-compatible HTML; markdown is not converted.
+            is_html: Whether to send the reply as HTML content (default: True).
+                Use false for plain text.
             mentions: Optional mentions to include. Accepts either raw Microsoft
                 Graph `mentions` objects or simplified items like
                 `{"name": "Jane Smith", "user_id": "..."}`.

--- a/tests/test_message_tools.py
+++ b/tests/test_message_tools.py
@@ -1,0 +1,49 @@
+import unittest
+
+from graph_mcp.tools.message_tools import (
+    build_chat_message_payload,
+    build_rich_text_body,
+)
+
+
+class RichTextBodyTests(unittest.TestCase):
+    def test_html_body_is_sent_exactly_without_markdown_conversion(self) -> None:
+        content = "**Codex notes** use YOUR_RESOURCE and `<code>`"
+
+        body = build_rich_text_body(content, is_html=True)
+
+        self.assertEqual(body["contentType"], "html")
+        self.assertEqual(body["content"], content)
+
+    def test_email_html_content_type_uses_exact_body(self) -> None:
+        content = "<p><strong>Ready</strong></p>"
+
+        body = build_rich_text_body(
+            content,
+            is_html=True,
+            html_content_type="HTML",
+            text_content_type="Text",
+        )
+
+        self.assertEqual(body["contentType"], "HTML")
+        self.assertEqual(body["content"], content)
+
+    def test_plain_text_body_is_sent_exactly(self) -> None:
+        content = "<p>not html when sent as text</p>"
+
+        body = build_rich_text_body(content, is_html=False)
+
+        self.assertEqual(body["contentType"], "text")
+        self.assertEqual(body["content"], content)
+
+    def test_chat_payload_uses_same_rich_text_contract(self) -> None:
+        payload = build_chat_message_payload("<p>Hello</p>", is_html=True)
+
+        self.assertEqual(
+            payload,
+            {"body": {"contentType": "html", "content": "<p>Hello</p>"}},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- stop auto-converting Teams and email bodies from Markdown to HTML
- preserve caller-provided content exactly for HTML and plain text bodies
- update Teams/email tool descriptions and README to require explicit HTML for formatted messages
- remove the unused Markdown dependency and add regression tests for message body formatting

## Why
The previous helper treated any tag-shaped text as already-HTML. A Markdown draft containing placeholders like `<your-name>` could therefore skip Markdown conversion, leak raw `**bold**` / fenced code markers into Teams, and let angle-bracket placeholders be interpreted as HTML tags.

## Verification
- `.venv/bin/python -m unittest discover -s tests -v`
- `.venv/bin/python -m build`