### PR TITLE
feat: add draft email tools (create, update, send)

### DIFF
--- a/src/graph_mcp/tools/mail_tools.py
+++ b/src/graph_mcp/tools/mail_tools.py
@@ -141,6 +141,98 @@ def register_mail_tools(mcp):
 
     @mcp.tool()
     @require_auth
+    async def graph_create_draft(
+        to: list[str],
+        subject: str,
+        body: str,
+        cc: list[str] | None = None,
+        is_html: bool = True,
+    ) -> str:
+        """Create a draft email without sending it.
+
+        Args:
+            to: List of recipient email addresses.
+            subject: Email subject.
+            body: Email body content. When `is_html` is true, send explicit
+                HTML; markdown is not converted.
+            cc: Optional list of CC email addresses.
+            is_html: Whether the body is HTML content (default: True).
+        """
+        message: dict = {
+            "subject": subject,
+            "body": build_rich_text_body(
+                body,
+                is_html,
+                html_content_type="HTML",
+                text_content_type="Text",
+            ),
+            "toRecipients": [
+                {"emailAddress": {"address": addr}} for addr in to
+            ],
+        }
+        if cc:
+            message["ccRecipients"] = [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ]
+        result = await graph_client.post("/me/messages", json_body=message)
+        return success_response(result)
+
+    @mcp.tool()
+    @require_auth
+    async def graph_update_draft(
+        message_id: str,
+        subject: str | None = None,
+        body: str | None = None,
+        to: list[str] | None = None,
+        cc: list[str] | None = None,
+        is_html: bool = True,
+    ) -> str:
+        """Update an existing draft email.
+
+        Args:
+            message_id: The draft message ID.
+            subject: New subject (omit to leave unchanged).
+            body: New body content (omit to leave unchanged).
+            to: New list of recipient email addresses (omit to leave unchanged).
+            cc: New list of CC email addresses (omit to leave unchanged).
+            is_html: Whether the body is HTML content (default: True).
+        """
+        updates: dict = {}
+        if subject is not None:
+            updates["subject"] = subject
+        if body is not None:
+            updates["body"] = build_rich_text_body(
+                body,
+                is_html,
+                html_content_type="HTML",
+                text_content_type="Text",
+            )
+        if to is not None:
+            updates["toRecipients"] = [
+                {"emailAddress": {"address": addr}} for addr in to
+            ]
+        if cc is not None:
+            updates["ccRecipients"] = [
+                {"emailAddress": {"address": addr}} for addr in cc
+            ]
+        result = await graph_client.patch(
+            f"/me/messages/{message_id}", json_body=updates
+        )
+        return success_response(result)
+
+    @mcp.tool()
+    @require_auth
+    async def graph_send_draft(message_id: str) -> str:
+        """Send an existing draft email.
+
+        Args:
+            message_id: The draft message ID to send.
+        """
+        await graph_client.post(f"/me/messages/{message_id}/send")
+        return success_response({"status": "Draft sent"})
+
+    @mcp.tool()
+    @require_auth
     async def graph_list_mail_attachments(message_id: str) -> str:
         """List attachments on an email message.
 


### PR DESCRIPTION
## Summary

Adds three new tools for managing email drafts via the Graph API:

- `graph_create_draft` — create a draft email without sending (`POST /me/messages`)
- `graph_update_draft` — modify subject, body, or recipients on an existing draft (`PATCH /me/messages/{id}`)
- `graph_send_draft` — send an existing draft (`POST /me/messages/{id}/send`)

These complement the existing `graph_send_mail` workflow for cases where the user wants to compose a message, review it in Outlook, and send manually — or where an agent prepares a draft for human review before sending.

## Scope requirement

These tools require `Mail.ReadWrite`, which is **not** added to the default scopes in this PR. Users who want draft functionality should add it to their Azure app registration's API permissions and include it in their token request.

A possible follow-up: add a `GRAPH_EXTRA_SCOPES` env var so users can extend the scope list without modifying source.

## Tested

- Created, updated, and sent drafts against a live Microsoft 365 tenant
- Verified drafts appear in the Drafts folder and send correctly
- Existing tests pass (`pytest tests/ -v` — 4/4)